### PR TITLE
Prevent default for action key events

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -339,30 +339,46 @@ function onClick(e: MouseEvent) {
     }
 }
 
+function specialKey(e: KeyboardEvent) {
+    return e.shiftKey || e.metaKey || e.ctrlKey || e.altKey;
+}
+
+function preventIfNotSpecial(e: KeyboardEvent) {
+    if (!specialKey(e)) {
+        e.preventDefault();
+    }
+}
+
 function onKeyDown(e: KeyboardEvent) {
     switch (e.code) {
-        case 'KeyA':
         case 'ArrowLeft':
+            preventIfNotSpecial(e);
+        case 'KeyA':
             leftKeyPressed = rightKeyPressed + 1;
             break;
-        case 'KeyD':
         case 'ArrowRight':
+            preventIfNotSpecial(e);
+        case 'KeyD':
             rightKeyPressed = leftKeyPressed + 1;
             break;
-        case 'KeyW':
         case 'ArrowUp':
+            preventIfNotSpecial(e);
+        case 'KeyW':
             upKeyPressed = downKeyPressed + 1;
             break;
-        case 'KeyS':
         case 'ArrowDown':
+            preventIfNotSpecial(e);
+        case 'KeyS':
             downKeyPressed = upKeyPressed + 1;
-            break;            
+            break;
         case 'Escape':
             exit();
-            break;    
+            break;
+        case 'Space':
+            preventIfNotSpecial(e);
         default:
             jumpKeyPressed = true;
-            break;            
+            break;
     }
 
     // touch testing


### PR DESCRIPTION
On certain displays, the screen overflows a bit, resulting in scrollbars appearing. This causes action arrow keys and space to scroll the screen annoyingly while playing.

Here's an example on Firefox 137.0.2 (the screen is small, but the behavior is the same on all screen sizes):

![2025-04-29 20 30 21](https://github.com/user-attachments/assets/60a21c28-62bc-4341-875c-f485e1e5eff8)

While it'd be ideal to get rid of these scrollbars (somewhat tricky to verify on all devices/browsers), a good contingency is to prevent default on action events, as this PR does. This keeps the screen stable during gameplay, even in cases when there are scrollbars.